### PR TITLE
Staged HV startup

### DIFF
--- a/pdb-slave/MARCH4-PDB/lib/PDBI2C/HVControl.cpp
+++ b/pdb-slave/MARCH4-PDB/lib/PDBI2C/HVControl.cpp
@@ -144,3 +144,24 @@ void HVControl::setAllHV(uint8_t code){
     }
     this->write();
 }
+
+void HVControl::setAllHVStagedStartup(uint8_t code){
+    // Loop through all HVOn pins and turn on HV depending on code
+    // Staged startup is meant to turn on all HV nets seperately, to minimize inrush currents
+    // Debug: turn on LED 4 if staged startup is called
+    DigitalOut debugLED(LED4, false);
+    debugLED = true;
+    for(int i = 0; i < sizeof(this->onPins)/sizeof(this->onPins[0]); i++){
+        if(this->getBit(code, i)){
+            // Turn on HV
+            this->clearBit(this->onPins[i]);
+            wait_ms(100); // Wait for a while before turning on a new net
+        }
+        else{
+            // Turn off HV
+            this->setBit(this->onPins[i]);
+        }
+        this->write();
+    }
+    debugLED = false;
+}

--- a/pdb-slave/MARCH4-PDB/lib/PDBI2C/HVControl.cpp
+++ b/pdb-slave/MARCH4-PDB/lib/PDBI2C/HVControl.cpp
@@ -145,12 +145,13 @@ void HVControl::setAllHV(uint8_t code){
     this->write();
 }
 
+// This function does the same as setAllHV, but turns on all HV nets seperately
+// Staged startup is designed with the purpose of minimizing inrush currents
 void HVControl::setAllHVStagedStartup(uint8_t code){
+    // Turn on LED 4 when staged startup is called
+    DigitalOut stagedStartupLED(LED4, false);
+    stagedStartupLED = true;
     // Loop through all HVOn pins and turn on HV depending on code
-    // Staged startup is meant to turn on all HV nets seperately, to minimize inrush currents
-    // Debug: turn on LED 4 if staged startup is called
-    DigitalOut debugLED(LED4, false);
-    debugLED = true;
     for(int i = 0; i < sizeof(this->onPins)/sizeof(this->onPins[0]); i++){
         if(this->getBit(code, i)){
             // Turn on HV
@@ -163,5 +164,6 @@ void HVControl::setAllHVStagedStartup(uint8_t code){
         }
         this->write();
     }
-    debugLED = false;
+    // Turn off LED 4 after staged startup has finished
+    stagedStartupLED = false;
 }

--- a/pdb-slave/MARCH4-PDB/lib/PDBI2C/HVControl.h
+++ b/pdb-slave/MARCH4-PDB/lib/PDBI2C/HVControl.h
@@ -59,6 +59,7 @@ public:
     uint8_t readAllReset();
     uint8_t readAllOn();
     void setAllHV(uint8_t code);
+    void setAllHVStagedStartup(uint8_t code);
 };
 
 

--- a/pdb-slave/MARCH4-PDB/src/main.cpp
+++ b/pdb-slave/MARCH4-PDB/src/main.cpp
@@ -145,7 +145,7 @@ int main(){
         if(stateMachine.getState() == "MasterOk_s" || stateMachine.getState() == "ShutdownInit_s"){
             // In an allowed state to have HV on
             emergencyButtonControl = mosi.emergencyButtonControl; // Enable HV, at least from software
-            uint8_t desiredHVStates = mosi.HVControl; // 2, 3, 6, 7 for HFE and KFE joints
+            uint8_t desiredHVStates = mosi.HVControl; // Whatever nets the master wants
             if (emergencyButtonState){  // HV enabled
                 if (hvOnStates != desiredHVStates){ // HV states not yet as desired
                     hvControl.setAllHVStagedStartup(desiredHVStates); // Staged startup to minimize inrush currents

--- a/pdb-slave/MARCH4-PDB/src/main.cpp
+++ b/pdb-slave/MARCH4-PDB/src/main.cpp
@@ -156,15 +156,15 @@ int main(){
             // emergencyButtonControl = mosi.emergencyButtonControl;
             // hvControl.setAllHV(mosi.HVControl);
             // hvControl.setAllHV(0b11111111) ;// Temporary, remove later!
-            hvControl.setAllHV(0b00000000); // Temporary, remove later!
+            hvControl.setAllHV(0b00000111); // Temporary, remove later!
             emergencyButtonControl = true; // Enable HV // Temporary, remove later!
         }
         else{
             // Not in an allowed state to have any HV on
             // hvControl.setAllHV(0b11111111); // Temporary, remove later!
             hvControl.setAllHV(0b00000000); // Temporary, remove later!
-            // emergencyButtonControl = false; // Disconnect HV
-            emergencyButtonControl = true; // Enable HV // Temporary, remove later!
+            emergencyButtonControl = false; // Disconnect HV
+            // emergencyButtonControl = true; // Enable HV // Temporary, remove later!
         }
         
         // Set miso's in EtherCAT buffers

--- a/pdb-slave/MARCH4-PDB/src/main.cpp
+++ b/pdb-slave/MARCH4-PDB/src/main.cpp
@@ -52,7 +52,7 @@ DigitalOut ecatIRQ(LPC_ECAT_IRQ, false);
 Ethercat ecat(LPC_ECAT_MOSI, LPC_ECAT_MISO, LPC_ECAT_SCK, LPC_ECAT_SCS, PDORX_size, PDOTX_size, &pc, 10);
 
 // Easy access to PDOs
-#define miso            Ethercat::pdoTx.Struct.miso	
+#define miso            Ethercat::pdoTx.Struct.miso
 #define mosi            Ethercat::pdoRx.Struct.mosi
 
 StateMachine stateMachine; // State machine instance

--- a/pdb-slave/MARCH4-PDB/src/main.cpp
+++ b/pdb-slave/MARCH4-PDB/src/main.cpp
@@ -42,16 +42,16 @@ union bit32 {
     uint32_t ui;
 };
 
-// EtherCAT	
-// Set PDO sizes	
-const int PDORX_size = 32;	
-const int PDOTX_size = 32;	
-// EtherCAT object	
-DigitalOut ecatReset(LPC_ECAT_RST, true);	
-DigitalOut ecatIRQ(LPC_ECAT_IRQ, false);	
-Ethercat ecat(LPC_ECAT_MOSI, LPC_ECAT_MISO, LPC_ECAT_SCK, LPC_ECAT_SCS, PDORX_size, PDOTX_size, &pc, 10);	
+// EtherCAT
+// Set PDO sizes
+const int PDORX_size = 32;
+const int PDOTX_size = 32;
+// EtherCAT object
+DigitalOut ecatReset(LPC_ECAT_RST, true);
+DigitalOut ecatIRQ(LPC_ECAT_IRQ, false);
+Ethercat ecat(LPC_ECAT_MOSI, LPC_ECAT_MISO, LPC_ECAT_SCK, LPC_ECAT_SCS, PDORX_size, PDOTX_size, &pc, 10);
 
- // Easy access to PDOs	
+// Easy access to PDOs
 #define miso            Ethercat::pdoTx.Struct.miso	
 #define mosi            Ethercat::pdoRx.Struct.mosi
 
@@ -83,7 +83,7 @@ int main(){
     masterOkTimer.start();
 
     while(1){
-        // Update EtherCAT variables	
+        // Update EtherCAT variables
         ecat.update();
 
         // Get inputs from digitalIns and I2C bus
@@ -161,15 +161,15 @@ int main(){
             hvControl.setAllHV(0b00000000); // Reset all HV nets to off, even though already disabled
         }
 
-        // Set miso's in EtherCAT buffers	
-        miso.emergencyButtonState = emergencyButtonState;	
-        miso.masterShutdown = stateMachine.getMasterShutdown();	
-        miso.HVOCTriggers = hvOCTriggerStates;	
-        miso.LVStates = (LVOkay2State << 1) | LVOkay1State;	
-        miso.HVStates = hvOnStates;	
-        miso.PDBCurrent = PDBCurrent.ui;	
-        miso.LV1Current = LV1Current.ui;	
-        miso.LV2Current = LV2Current.ui;	
+        // Set miso's in EtherCAT buffers
+        miso.emergencyButtonState = emergencyButtonState;
+        miso.masterShutdown = stateMachine.getMasterShutdown();
+        miso.HVOCTriggers = hvOCTriggerStates;
+        miso.LVStates = (LVOkay2State << 1) | LVOkay1State;
+        miso.HVStates = hvOnStates;
+        miso.PDBCurrent = PDBCurrent.ui;
+        miso.LV1Current = LV1Current.ui;
+        miso.LV2Current = LV2Current.ui;
         miso.HVCurrent = HVCurrent.ui;
     }
     

--- a/pdb-slave/MARCH4-PDB/src/main.cpp
+++ b/pdb-slave/MARCH4-PDB/src/main.cpp
@@ -96,7 +96,7 @@ int main(){
         // Control HV
         if(stateMachine.getState() == "MasterOk_s" || stateMachine.getState() == "ShutdownInit_s"){
             // In an allowed state to have HV on
-            hvControl.setAllHV(0b00000111);
+            hvControl.setAllHV(0b01100110); // 2, 3, 6, 7
             emergencyButtonControl = true; // Enable HV
         }
         else{


### PR DESCRIPTION
You asked, I delivered! A small PR this time, with only a few lines changed.

This allows high voltage nets to be turned on with a small delay (100 ms) between each net. This should limit the inrush currents. On the exoskeleton, this seems to work, since the master has not been turning off any more after releasing the emergency button.

What I want your opinion on is if you want to keep LED4 turning on when doing the staged startup. It was initially just a debug tool, but I kinda like it and think it could be kept as a feature.
