### PR TITLE
allow hv on before masterok

### DIFF
--- a/pdb-slave/MARCH4-PDB/lib/StateMachine/StateMachine.cpp
+++ b/pdb-slave/MARCH4-PDB/lib/StateMachine/StateMachine.cpp
@@ -78,8 +78,11 @@ void StateMachine::updateState(bool buttonState, bool masterOkState, bool shutdo
                 this->ledTimer.start();
             }
             if(!masterOkState){
-                this->currentState = LVOn_s;
+                this->currentState = MasterLost_s;
             }
+            break;
+        case MasterLost_s:
+            this->currentState = LVOn_s;
             break;
         case ShutdownInit_s:
             this->masterShutdown = true;

--- a/pdb-slave/MARCH4-PDB/lib/StateMachine/States.h
+++ b/pdb-slave/MARCH4-PDB/lib/StateMachine/States.h
@@ -4,6 +4,7 @@
 enum State {    Init_s,
                 LVOn_s,
                 MasterOk_s,
+                MasterLost_s,
                 ShutdownInit_s,
                 Shutdown_s,
                 TurnOff_s};

--- a/pdb-slave/MARCH4-PDB/src/main.cpp
+++ b/pdb-slave/MARCH4-PDB/src/main.cpp
@@ -142,7 +142,7 @@ int main(){
         LVOn2 = stateMachine.getLVOn(); // (For now) Don't listen to what master says over EtherCAT: LV net 2 not controllable by master
 
         // Control HV
-        if(stateMachine.getState() == "MasterOk_s" || stateMachine.getState() == "ShutdownInit_s"){
+        if(stateMachine.getState() == "MasterOk_s" || stateMachine.getState() == "ShutdownInit_s" || stateMachine.getState() == "LVOn_s"){
             // In an allowed state to have HV on
             emergencyButtonControl = mosi.emergencyButtonControl; // Enable HV, at least from software
             uint8_t desiredHVStates = mosi.HVControl; // Whatever nets the master wants


### PR DESCRIPTION
Required because of master-pdb start-up sequence issues: master needs to turn on hv before it is in normal operation because it needs hv to get imcs to operation enabled