### PR TITLE
Fix Undervoltage errors

### DIFF
--- a/pdb-slave/MARCH4-PDB/lib/StateMachine/StateMachine.cpp
+++ b/pdb-slave/MARCH4-PDB/lib/StateMachine/StateMachine.cpp
@@ -78,11 +78,8 @@ void StateMachine::updateState(bool buttonState, bool masterOkState, bool shutdo
                 this->ledTimer.start();
             }
             if(!masterOkState){
-                this->currentState = MasterLost_s;
+                this->currentState = LVOn_s;
             }
-            break;
-        case MasterLost_s:
-            this->currentState = LVOn_s;
             break;
         case ShutdownInit_s:
             this->masterShutdown = true;

--- a/pdb-slave/MARCH4-PDB/lib/StateMachine/States.h
+++ b/pdb-slave/MARCH4-PDB/lib/StateMachine/States.h
@@ -4,7 +4,6 @@
 enum State {    Init_s,
                 LVOn_s,
                 MasterOk_s,
-                MasterLost_s,
                 ShutdownInit_s,
                 Shutdown_s,
                 TurnOff_s};

--- a/pdb-slave/MARCH4-PDB/src/main.cpp
+++ b/pdb-slave/MARCH4-PDB/src/main.cpp
@@ -105,7 +105,7 @@ int main(){
             masterUpToDate = true;
             missedMasterCounter = 0;
         }
-        else if(masterOkTimer.read_ms() > 1000){ // More than 1000 ms since last masterOk signal
+        else if(masterOkTimer.read_ms() > 100){ // More than 100 ms since last masterOk signal
             masterUpToDate = false;
         }
         lastMasterOk = mosi.masterOk;

--- a/pdb-slave/MARCH4-PDB/src/main.cpp
+++ b/pdb-slave/MARCH4-PDB/src/main.cpp
@@ -105,7 +105,7 @@ int main(){
             masterUpToDate = true;
             missedMasterCounter = 0;
         }
-        else if(masterOkTimer.read_ms() > 100){ // More than 100 ms since last masterOk signal
+        else if(masterOkTimer.read_ms() > 1000){ // More than 1000 ms since last masterOk signal
             masterUpToDate = false;
         }
         lastMasterOk = mosi.masterOk;


### PR DESCRIPTION
This removes a state from the PDB state machine. This state caused HV to be turned off when entered. It was meant to be entered when communication was lost between master and PDB, but I suspect it was also entered sometimes where it shouldn't have, causing undervoltage errors. 

The original intent of the state was to turn off HV when the hardware interface crashes/is stopped, but this is in fact not needed since the IMC will go to fault state anyways when the hardware interface crashes/is stopped.

This should close https://github.com/project-march/hardware-interface/issues/113